### PR TITLE
Fix trace panic

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo test --all-features --release
+      - run: RUST_LOG=trace cargo test --all-features --release
       - run: cargo clippy -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# v0.4.3
+## Bugs
+* Fixed a panic caused by an unchecked `unwrap()` in a `trace!` statement
+
+# v0.4.2
+Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "waffle_con"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 derive_builder = "0.13.0"
-env_logger = "0.11.1"
 itertools = "0.12.1"
 log = "0.4.20"
 priority-queue = "1.3.2"
@@ -19,6 +18,7 @@ rand = "0.8.5"
 criterion = "0.5.1"
 csv = "1.3.0"
 serde = "1.0.197"
+test-log = "0.2.16"
 
 [[bench]]
 name = "consensus_bench"

--- a/src/dual_consensus.rs
+++ b/src/dual_consensus.rs
@@ -478,6 +478,13 @@ impl<'a> DualConsensusDWFA<'a> {
                         trace!("\tadding to ret");//: {dual_con_result:?}");
                         trace!("\tcon1: {}", std::str::from_utf8(dual_con_result.consensus1().sequence())?);
                         trace!("\tcon2: {}", std::str::from_utf8(dual_con_result.consensus2().unwrap().sequence())?);
+                        /*
+                        if let Some(c2) = dual_con_result.consensus2() {
+                            trace!("\tcon2: {}", std::str::from_utf8(c2.sequence())?);
+                        } else {
+                            trace!("\tcon2: None");
+                        }
+                        */
                         ret.push(dual_con_result);
                     }
                 } else {
@@ -1481,8 +1488,9 @@ mod tests {
         assert_eq!(consensus, vec![expected_consensus]);
     }
 
-    #[test]
+    #[test_log::test]
     fn test_single_sequence() {
+        // the sequence
         let sequence = b"ACGTACGTACGT";
         let mut consensus_dwfa = DualConsensusDWFA::default();
         consensus_dwfa.add_sequence(sequence).unwrap();

--- a/src/dual_consensus.rs
+++ b/src/dual_consensus.rs
@@ -477,14 +477,11 @@ impl<'a> DualConsensusDWFA<'a> {
                         );
                         trace!("\tadding to ret");//: {dual_con_result:?}");
                         trace!("\tcon1: {}", std::str::from_utf8(dual_con_result.consensus1().sequence())?);
-                        trace!("\tcon2: {}", std::str::from_utf8(dual_con_result.consensus2().unwrap().sequence())?);
-                        /*
                         if let Some(c2) = dual_con_result.consensus2() {
                             trace!("\tcon2: {}", std::str::from_utf8(c2.sequence())?);
                         } else {
                             trace!("\tcon2: None");
                         }
-                        */
                         ret.push(dual_con_result);
                     }
                 } else {


### PR DESCRIPTION
# v0.4.3
## Bugs
* Fixed a panic caused by an unchecked `unwrap()` in a `trace!` statement